### PR TITLE
Fix route setup naming.

### DIFF
--- a/src/Traits/DropzoneTrait.php
+++ b/src/Traits/DropzoneTrait.php
@@ -12,7 +12,7 @@ use Prodixx\DropzoneFieldForBackpack\Http\Requests\DropzoneRequest;
 
 trait DropzoneTrait
 {
-    protected function setupModerateRoutes($segment, $routeName, $controller)
+    protected function setupDropzoneRoutes($segment, $routeName, $controller)
     {
         Route::post($segment . '/dropzone-add', [
             'as'        => $routeName . '.dropzone-add',


### PR DESCRIPTION
I think this was a leftover from the example. 
It would conflict with anyone that has a `Moderate` operation and used that name in the setup routes function. 

BTW, thanks for sharing this, I will test it later and let you know if I found something that can be improved/fixed :)

Best,
Pedro